### PR TITLE
[bugfix] restart button sometimes does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ Unit testing in Picotron.
 
 ## How to use?
 
-* download cart from [releases page](https://github.com/elgopher/unitron/releases) and put it somewhere on Picotron drive (desktop for example)
-* run the cart
-* create a file with test code:
+* download cart png from [releases page](https://github.com/elgopher/unitron/releases) and put it somewhere on Picotron drive (desktop for example)
+* run the cart by double clicking 
+* create a Lua file with following test code:
 
 ```lua
 assert_eq("hello", "hello")
 ```
 
-* drag'n'drop the file to unitron window
+* drag and drop the file to unitron window
 * see [examples](examples) folder for details how to write tests
 
 ## Development - how to work on unitron

--- a/gui.lua
+++ b/gui.lua
@@ -198,6 +198,15 @@ function _init()
 				{ argv = { test_file }, path = work_dir, window_attribs = { autoclose = true } })
 		end
 
+		local text_area = attach_textarea(gui, { x = 0, y = 97, width = width, height = 103 })
+
+		test_tree = attach_tree(gui, { x = 0, y = 16, width = width, height = 80 })
+		function test_tree:select(e)
+			selected_test = e.id
+			local lines = printed_lines:lines(e.id)
+			text_area:set_lines(lines)
+		end
+
 		local toolbar = gui:attach { x = 0, y = 0, width = width, height = 16 }
 		function toolbar:draw()
 			rectfill(0, 0, self.width, self.height, toolbar_color)
@@ -255,15 +264,6 @@ function _init()
 		-- 	spr(2)
 		-- 	pal()
 		-- end
-
-		local text_area = attach_textarea(gui, { x = 0, y = 100, width = width, height = 100 })
-
-		test_tree = attach_tree(gui, { x = 0, y = 16, width = width, height = 80 })
-		function test_tree:select(e)
-			selected_test = e.id
-			local lines = printed_lines:lines(e.id)
-			text_area:set_lines(lines)
-		end
 
 		run_tests_in_seperate_process()
 	end


### PR DESCRIPTION
Restart button does not work when test tree is scrolled down to the bottom.

Draw toolbar with buttons as a last element, so that it receives click events.