### PR TITLE
Go to Lua editor directly from test output

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -34,9 +34,9 @@ local function equal(expected, actual, visited_values)
 	local function userdata_type(u)
 		-- dirty hack because I dont know the method to get userdata type
 		-- TODO OPTIMIZE IT
-		local p = pod(u)                 -- pod(u) returns userdata("u8",2,2,"02030405")
+		local p = pod(u)                   -- pod(u) returns userdata("u8",2,2,"02030405")
 		p = string.gsub(p, "userdata%(\"", "") -- drop userdata("
-		p = string.gsub(p, "\".*", "")   -- drop ").*
+		p = string.gsub(p, "\".*", "")     -- drop ").*
 		return p
 	end
 
@@ -77,7 +77,7 @@ local function get_caller()
 	local traceback = debug.traceback("", 3)
 	local loc = split(traceback, "\n")[3]
 	loc = string.gsub(loc, "(%d+):.*", "%1") -- drop message
-	loc = string.gsub(loc, "\t", "")      -- drop tabulator
+	loc = string.gsub(loc, "\t", "")       -- drop tabulator
 	return loc
 end
 
@@ -99,7 +99,7 @@ end
 
 local function serialize_message(msg)
 	if msg == nil then
-		return nil 
+		return nil
 	end
 
 	return tostring(msg)
@@ -109,8 +109,8 @@ end
 ---
 ---For strings, numbers and booleans '==' operator is used.
 ---
----For tables, all keys and values are compared deeply. 
----If you want to compare if two tables points to the same address in memory please use assert_same instead. 
+---For tables, all keys and values are compared deeply.
+---If you want to compare if two tables points to the same address in memory please use assert_same instead.
 ---Tables could have cycles.
 ---
 ---For userdata, all data is compared and userdata must be of the same type, width and height.
@@ -187,8 +187,8 @@ function assert_not_close(not_expected, actual, delta, msg)
 		local err = {
 			assert = "not_close",
 			not_expected = tostring(not_expected), -- TODO Picotron has a bug that small numbers are not properly serialized
-			actual = tostring(actual), -- TODO Picotron has a bug that small numbers are not properly serialized
-			delta = tostring(delta), -- TODO Picotron has a bug that small numbers are not properly serialized
+			actual = tostring(actual),       -- TODO Picotron has a bug that small numbers are not properly serialized
+			delta = tostring(delta),         -- TODO Picotron has a bug that small numbers are not properly serialized
 			msg = serialize_message(msg),
 			file = get_caller(),
 		}

--- a/cli.lua
+++ b/cli.lua
@@ -20,7 +20,7 @@ on_event("test_finished", function(e)
 end)
 
 on_event("print", function(e)
-	printh("test " .. e.test.id .. ": " .. e.text) -- print to stdout, because Picotron's terminal has limited size. 
+	printh("test " .. e.test.id .. ": " .. e.text) -- print to stdout, because Picotron's terminal has limited size.
 end)
 
 on_event("done", function(e)
@@ -43,4 +43,3 @@ runner_pid = create_process("runner.lua",
 
 function _update() -- run in the background
 end
-

--- a/examples/subject.lua
+++ b/examples/subject.lua
@@ -7,28 +7,29 @@
 ---@param right string
 ---@return string
 function concat(left, right)
-    return left .. right
+	return left .. right
 end
 
 ---@param left number
 ---@param right number
 ---@return number
 function divide(left, right)
-    return left / right
+	return left / right
 end
 
 ---@param left number
 ---@param right number
 ---@return number
 function add(left, right)
-    return left + right
+	return left + right
 end
 
 ---@return table
 function new_player()
-    local player = { position = 0 }
-    function player:collides(other_player)
-        return player.position == other_player.position
-    end
-    return player
+	local player = { position = 0 }
+	function player:collides(other_player)
+		return player.position == other_player.position
+	end
+
+	return player
 end

--- a/examples/subject_test.lua
+++ b/examples/subject_test.lua
@@ -4,94 +4,94 @@
 include "subject.lua" -- include the "production" code which will be tested here
 
 test("compare strings", function()
-    local s = concat("hello ", "world")
-    -- change with assert_not_eq to get test error:
-    assert_eq("hello world", s)                                
-    -- assertions can have optional message which is presented in the unitron's
-    -- user interface: 
-    assert_eq("hello world", s, "should return \"hello world\"")
+	local s = concat("hello ", "world")
+	-- change with assert_not_eq to get test error:
+	assert_eq("hello world", s)
+	-- assertions can have optional message which is presented in the unitron's
+	-- user interface:
+	assert_eq("hello world", s, "should return \"hello world\"")
 end)
 
 test("compare tables", function()
-    local expected = {
-        a = "a value",
-        b = "b value",
-    }
-    local actual = {
-        a = "a value",
-        b = "b value",
-    }
-    assert_eq(expected, actual) -- tables are compared deeply
+	local expected = {
+		a = "a value",
+		b = "b value",
+	}
+	local actual = {
+		a = "a value",
+		b = "b value",
+	}
+	assert_eq(expected, actual) -- tables are compared deeply
 end)
 
 test("compare numbers", function()
-    local sum = divide(10.444, 9.99)
-    local delta = 0.0001
-    assert_close(1.0454, sum, delta)
+	local sum = divide(10.444, 9.99)
+	local delta = 0.0001
+	assert_close(1.0454, sum, delta)
 end)
 
-test("compare userdata", function ()
-    local u1 = userdata("u8", 2, 2, "00010203")
-    local u2 = userdata("u8", 2, 2, "00010203")
-    assert_eq(u1, u2)
+test("compare userdata", function()
+	local u1 = userdata("u8", 2, 2, "00010203")
+	local u2 = userdata("u8", 2, 2, "00010203")
+	assert_eq(u1, u2)
 end)
 
 test("assert nil", function()
-    local v = nil
-    assert_nil(v)
+	local v = nil
+	assert_nil(v)
 end)
 
 -- sometimes you want to be sure that two tables are pointing to the same address
 -- in memory
 test("compare pointers", function()
-    local t = { key = "value" }
-    local pointer_to_t = t
-    assert_same(t, pointer_to_t) -- internally assert_same just runs expected==actual
+	local t = { key = "value" }
+	local pointer_to_t = t
+	assert_same(t, pointer_to_t) -- internally assert_same just runs expected==actual
 end)
 
 -- standard assert function can be used too to veryify if argument is true
 test("standard assert aka assert true", function()
-    assert(true)
+	assert(true)
 end)
 
 -- you can nest tests multiple times. This is useful in grouping similar tests.
 test("nesting tests", function()
-    test("nested test", function()
-        assert(true)
-    end)
-    test("another nested test", function()
-        test("yet another", function()
-            assert(true)
-        end)
-    end)
+	test("nested test", function()
+		assert(true)
+	end)
+	test("another nested test", function()
+		test("yet another", function()
+			assert(true)
+		end)
+	end)
 end)
 
--- table driven tests are the kind of nested tests which use tests defined in tables. 
+-- table driven tests are the kind of nested tests which use tests defined in tables.
 -- This greatly reduces amount of code.
 test("table driven tests", function()
-    local tests = {
-     	 -- first test case with name "2+2=4".
-     	 -- You can drop square brackets and quotes when key does not have special
-     	 -- characters.
-        ["2+2=4"] = { left = 2, right = 2, expected_sum = 4 },
-        ["0+1=1"] = { left = 0, right = 1, expected_sum = 1 }  -- second test case
-    }
+	local tests = {
+		-- first test case with name "2+2=4".
+		-- You can drop square brackets and quotes when key does not have special
+		-- characters.
+		["2+2=4"] = { left = 2, right = 2, expected_sum = 4 },
+		["0+1=1"] = { left = 0, right = 1, expected_sum = 1 } -- second test case
+	}
 
-    for test_name, test_case in pairs(tests) do
-        -- start nested test with test case name so when there is an error 
-        -- you will know which specific test case failed:
-        test(test_name, function()
-            local sum = add(test_case.left, test_case.right)
-            assert_eq(test_case.expected_sum, sum)
-        end)
-    end
+	for test_name, test_case in pairs(tests) do
+		-- start nested test with test case name so when there is an error
+		-- you will know which specific test case failed:
+		test(test_name, function()
+			local sum = add(test_case.left, test_case.right)
+			assert_eq(test_case.expected_sum, sum)
+		end)
+	end
 end)
 
 -- test can be slow, but don't worry - it does not block the unitron ui
-test("slow test", function ()
-    for i = 1, 1000000 do
-        spr(0, 30, 30) -- drawing sprites also does not break the unitron ui
-    end
+test("slow test", function()
+	for i = 1, 1000000 do
+		spr(0, 30, 30) -- drawing sprites also does not break the unitron ui
+	end
 end)
 
 -- sometimes you want to reuse variables in multiple tests. Reusing
@@ -100,28 +100,27 @@ end)
 -- have independent tests. You can use a setup function which will
 -- re-initialize these variables on the beginning of each test.
 test("test with setup function", function()
-    local player1, player2 -- these variables will be reused
- 
-    -- setup will be run on the beginning of each test:
-    local function setup()
-        player1 = new_player()
-        player1.position = 1
-        player2 = new_player()  
-        player2.position = 2
-    end
+	local player1, player2 -- these variables will be reused
 
-    test("players should collide", function ()
-        setup() -- initialize players
-        -- following line modifies player2, so the next test will be
-        -- affected, if the player2 is not re-initialized
-        player2.position = player1.position
-        assert(player1:collides(player2))
-    end)
-    
-    test("players should not collide", function ()
-        -- initialize players again. setup will override local player variables:
-        setup()  
-        assert(not player1:collides(player2))
-    end)
+	-- setup will be run on the beginning of each test:
+	local function setup()
+		player1 = new_player()
+		player1.position = 1
+		player2 = new_player()
+		player2.position = 2
+	end
 
+	test("players should collide", function()
+		setup() -- initialize players
+		-- following line modifies player2, so the next test will be
+		-- affected, if the player2 is not re-initialized
+		player2.position = player1.position
+		assert(player1:collides(player2))
+	end)
+
+	test("players should not collide", function()
+		-- initialize players again. setup will override local player variables:
+		setup()
+		assert(not player1:collides(player2))
+	end)
 end)

--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -88,7 +88,7 @@ on_event("test_finished", function(e)
 
 	if e.error == nil then
 		lights:set_light(e.test.id, 26)
-		test_summary:inc_succeded()
+		test_summary:inc_succeeded()
 	else
 		lights:set_light(e.test.id, 8)
 		test_summary:inc_failed()

--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -216,6 +216,28 @@ function _init()
 
 		local text_area = attach_textarea(gui, { x = 0, y = 97, width = width, height = 103 })
 
+		local function find_lua_file_in_text(text)
+			return text:match("[^ ]*%.lua:%d+")
+		end
+
+		function text_area:is_link(text)
+			return text != nil and find_lua_file_in_text(text) != nil
+		end
+
+		function text_area:link_click(text)
+			if text == nil then return end
+
+			local file = find_lua_file_in_text(text)
+			if file != nil then
+				file = file:gsub(":", "#")
+				-- TODO if file is already open in text editor then this
+				-- command does not go to the specific line number.
+				-- Please note though, that in case of an unhandled error,
+				-- Picotron also opens the text editor in the same way.
+				create_process("/system/util/open.lua", { argv = { file } })
+			end
+		end
+
 		test_summary = attach_test_summary(gui, { x = 8, y = 102, width = 150, height = 10 })
 
 		local function select_test(test_id)

--- a/gui/lights.lua
+++ b/gui/lights.lua
@@ -4,69 +4,69 @@
 -- lights is a gui component showing lights of different color :)
 
 function attach_lights(gui, el)
-    local lights = {}
-    local lights_max = 0
-    local size = 2 -- light size in pixels
+	local lights = {}
+	local lights_max = 0
+	local size = 2 -- light size in pixels
 
-    local container = gui:attach(el)
+	local container = gui:attach(el)
 
-    function container:set_light(no, color)
-        lights[no] = color
-        lights_max = max(lights_max, no)
-    end
+	function container:set_light(no, color)
+		lights[no] = color
+		lights_max = max(lights_max, no)
+	end
 
-    local function light_at_cursor_pointer(msg)
-        if msg.mx == nil and msg.my == nil then
-            return
-        end
-        local cell = ceil((msg.mx + 1) / (size * 2))
-        local row = ceil(msg.my / (size * 2)) - 1
-        local number_of_cells_in_a_row = el.width / (size * 2)
-        local light = row * number_of_cells_in_a_row + cell
-        if light > 0 and light <= lights_max then
-            return light
-        end
-        return nil
-    end
+	local function light_at_cursor_pointer(msg)
+		if msg.mx == nil and msg.my == nil then
+			return
+		end
+		local cell = ceil((msg.mx + 1) / (size * 2))
+		local row = ceil(msg.my / (size * 2)) - 1
+		local number_of_cells_in_a_row = el.width / (size * 2)
+		local light = row * number_of_cells_in_a_row + cell
+		if light > 0 and light <= lights_max then
+			return light
+		end
+		return nil
+	end
 
-    function container:update(msg)
-        if light_at_cursor_pointer(msg) != nil then
-            container.cursor = "pointer"
-        else
-            container.cursor = ""
-        end
-    end
+	function container:update(msg)
+		if light_at_cursor_pointer(msg) != nil then
+			container.cursor = "pointer"
+		else
+			container.cursor = ""
+		end
+	end
 
-    function container:click(msg)
-        local light = light_at_cursor_pointer(msg)
-        if light != nil then
-            el:select(light)
-        end
-    end
+	function container:click(msg)
+		local light = light_at_cursor_pointer(msg)
+		if light != nil then
+			el:select(light)
+		end
+	end
 
-    function container:draw()
-        rectfill(0, 0, el.width, el.height, 0)
-        local x, y = 0, 0
+	function container:draw()
+		rectfill(0, 0, el.width, el.height, 0)
+		local x, y = 0, 0
 
-        for i = 1, lights_max do
-            local light = lights[i]
-            if light == nil then
-                light = 0
-            end
+		for i = 1, lights_max do
+			local light = lights[i]
+			if light == nil then
+				light = 0
+			end
 
-            rectfill(x, y, x + size, y + size, light)
+			rectfill(x, y, x + size, y + size, light)
 
-            if x >= el.width then
-                x = 0
-                y += size * 2
-                if y >= el.height then
-                    return
-                end
-            else
-                x += size * 2
-            end
-        end
-    end
+			if x >= el.width then
+				x = 0
+				y += size * 2
+				if y >= el.height then
+					return
+				end
+			else
+				x += size * 2
+			end
+		end
+	end
 
-    return container
+	return container
 end

--- a/gui/test_summary.lua
+++ b/gui/test_summary.lua
@@ -2,23 +2,23 @@
 -- This code is licensed under MIT license (see LICENSE for details)
 
 function attach_test_summary(gui, el)
-    local succeeded, failed = 0, 0
+	local succeeded, failed = 0, 0
 
-    local container = gui:attach(el)
+	local container = gui:attach(el)
 
-    function container:draw()
-        rectfill(0, 0, el.width, el.height, 0)
-        color(26)
-        print("Succeeded: " .. succeeded .. " \f8 Failed: " .. failed)
-    end
+	function container:draw()
+		rectfill(0, 0, el.width, el.height, 0)
+		color(26)
+		print("Succeeded: " .. succeeded .. " \f8 Failed: " .. failed)
+	end
 
-    function container:inc_succeeded()
-        succeeded += 1
-    end
+	function container:inc_succeeded()
+		succeeded += 1
+	end
 
-    function container:inc_failed()
-        failed += 1
-    end
+	function container:inc_failed()
+		failed += 1
+	end
 
-    return container
+	return container
 end

--- a/gui/test_summary.lua
+++ b/gui/test_summary.lua
@@ -2,18 +2,18 @@
 -- This code is licensed under MIT license (see LICENSE for details)
 
 function attach_test_summary(gui, el)
-    local succeded, failed = 0, 0
+    local succeeded, failed = 0, 0
 
     local container = gui:attach(el)
 
     function container:draw()
         rectfill(0, 0, el.width, el.height, 0)
         color(26)
-        print("Succeded: " .. succeded .. " \f8 Failed: " .. failed)
+        print("Succeeded: " .. succeeded .. " \f8 Failed: " .. failed)
     end
 
-    function container:inc_succeded()
-        succeded += 1
+    function container:inc_succeeded()
+        succeeded += 1
     end
 
     function container:inc_failed()

--- a/gui/textarea.lua
+++ b/gui/textarea.lua
@@ -11,6 +11,31 @@ function attach_textarea(gui, el)
 
 	local lines = {}
 
+	local function text_at_mouse_position(msg)
+		return lines[ceil(msg.my / line_height)]
+	end
+
+	local function is_link(text)
+		return el.is_link != nil and el:is_link(text)
+	end
+
+	function text_area:update(msg)
+		if msg.my == nil then return end -- outside the window
+		local cursor = ""
+		local text = text_at_mouse_position(msg)
+		if is_link(text) then
+			cursor = "pointer"
+		end
+		text_area.cursor = cursor
+	end
+
+	function text_area:click(msg)
+		local text = text_at_mouse_position(msg)
+		if is_link(text) and el.link_click != nil then
+			el:link_click(text)
+		end
+	end
+
 	function text_area:draw()
 		local y = 0
 		for _, line in ipairs(lines) do

--- a/gui/textarea.lua
+++ b/gui/textarea.lua
@@ -2,32 +2,32 @@
 -- This code is licensed under MIT license (see LICENSE for details)
 
 function attach_textarea(gui, el)
-    local line_height = 10
+	local line_height = 10
 
-    el.draw = function() end -- draw is needed for clipping
-    local container = gui:attach(el)
-    local text_area = container:attach({ x = 0, y = 0, width = el.width, height = 0 })
-    container:attach_scrollbars { autohide = true }
+	el.draw = function() end -- draw is needed for clipping
+	local container = gui:attach(el)
+	local text_area = container:attach({ x = 0, y = 0, width = el.width, height = 0 })
+	container:attach_scrollbars { autohide = true }
 
-    local lines = {}
+	local lines = {}
 
-    function text_area:draw()
-        local y = 0
-        for _, line in ipairs(lines) do
-            print(line, 0, y, 7)
-            y += line_height
-        end
-    end
+	function text_area:draw()
+		local y = 0
+		for _, line in ipairs(lines) do
+			print(line, 0, y, 7)
+			y += line_height
+		end
+	end
 
-    function text_area:mousewheel(e)
-        self.y += e.wheel_y * 32
-    end
+	function text_area:mousewheel(e)
+		self.y += e.wheel_y * 32
+	end
 
-    function container:set_lines(lines_to_draw)
-        text_area.y = 0
-        lines = lines_to_draw
-        text_area.height = line_height * #lines
-    end
+	function container:set_lines(lines_to_draw)
+		text_area.y = 0
+		lines = lines_to_draw
+		text_area.height = line_height * #lines
+	end
 
-    return container
+	return container
 end

--- a/gui/tree.lua
+++ b/gui/tree.lua
@@ -2,114 +2,114 @@
 -- This code is licensed under MIT license (see LICENSE for details)
 
 function attach_tree(gui, el)
-  local bg_color = 7
-  local fg_color = 13
-  local highlight_bg_color = 1
-  local highlight_fg_color = 7
+	local bg_color = 7
+	local fg_color = 13
+	local highlight_bg_color = 1
+	local highlight_fg_color = 7
 
-  local node_height = 10
+	local node_height = 10
 
-  local nodes_by_id = {}
+	local nodes_by_id = {}
 
-  local selected_child
+	local selected_child
 
-  el.draw = function() end -- needed for scrollbars clipping
-  local container = gui:attach(el)
-  local root_node = container:attach({ width = el.width, height = node_height, x = 0, y = 0 })
-  root_node.indent = ""
-  container:attach_scrollbars { autohide = true }
+	el.draw = function() end -- needed for scrollbars clipping
+	local container = gui:attach(el)
+	local root_node = container:attach({ width = el.width, height = node_height, x = 0, y = 0 })
+	root_node.indent = ""
+	container:attach_scrollbars { autohide = true }
 
-  function container:add_child(id, text, parent_id)
-    local parent
-    if parent_id == nil then
-      parent = root_node
-    else
-      parent = nodes_by_id[parent_id]
-    end
+	function container:add_child(id, text, parent_id)
+		local parent
+		if parent_id == nil then
+			parent = root_node
+		else
+			parent = nodes_by_id[parent_id]
+		end
 
 
-    local child = parent:attach({ width = parent.width, height = node_height, x = 0, y = parent.height })
-    child.text = text
-    child.indent = parent.indent .. "  "
-    if parent_id == nil then
-      child.indent = "" -- root element should not have an indent
-    end
-    function child:draw(msg)
-      if child == selected_child then
-        pal(bg_color, highlight_bg_color); pal(fg_color, highlight_fg_color)
-      end
-      local prefix = "[-] "
-      if #child.child == 0 then
-        prefix = "    "
-      end
-      rectfill(0, 0, self.width, node_height, bg_color)
-      print(child.indent .. prefix .. self.text, 0, 1, fg_color)
-      pal()
-    end
+		local child = parent:attach({ width = parent.width, height = node_height, x = 0, y = parent.height })
+		child.text = text
+		child.indent = parent.indent .. "  "
+		if parent_id == nil then
+			child.indent = "" -- root element should not have an indent
+		end
+		function child:draw(msg)
+			if child == selected_child then
+				pal(bg_color, highlight_bg_color); pal(fg_color, highlight_fg_color)
+			end
+			local prefix = "[-] "
+			if #child.child == 0 then
+				prefix = "    "
+			end
+			rectfill(0, 0, self.width, node_height, bg_color)
+			print(child.indent .. prefix .. self.text, 0, 1, fg_color)
+			pal()
+		end
 
-    function child:click()
-      selected_child = child
-      el:select { id = id }
-      return true
-    end
+		function child:click()
+			selected_child = child
+			el:select { id = id }
+			return true
+		end
 
-    local function add_height(parent, h)
-      parent.height += h
-      if parent._parent != nil then
-        add_height(parent._parent, h)
-      end
-    end
+		local function add_height(parent, h)
+			parent.height += h
+			if parent._parent != nil then
+				add_height(parent._parent, h)
+			end
+		end
 
-    add_height(parent, node_height)
+		add_height(parent, node_height)
 
-    child._parent = parent -- use _parent beause parent is already used by Picotron
-    nodes_by_id[id] = child
-    child.cursor = "pointer"
-  end
+		child._parent = parent -- use _parent beause parent is already used by Picotron
+		nodes_by_id[id] = child
+		child.cursor = "pointer"
+	end
 
-  function container:draw()
-    rectfill(0, 0, container.width, container.height, bg_color)
-  end
+	function container:draw()
+		rectfill(0, 0, container.width, container.height, bg_color)
+	end
 
-  function container:update_child_text(id, text)
-    nodes_by_id[id].text = text
-  end
+	function container:update_child_text(id, text)
+		nodes_by_id[id].text = text
+	end
 
-  function container:reset()
-    for _, child in ipairs(root_node.child) do
-      child:detach()
-    end
-    root_node.y = 0
-    root_node.height = node_height
-    root_node.height = 0
-  end
+	function container:reset()
+		for _, child in ipairs(root_node.child) do
+			child:detach()
+		end
+		root_node.y = 0
+		root_node.height = node_height
+		root_node.height = 0
+	end
 
-  local function child_y_relative_to_root_node(child)
-    local y = child.y
-    while child.parent != root_node do
-      y += child.parent.y
-      child = child.parent
-    end
-    return y
-  end
+	local function child_y_relative_to_root_node(child)
+		local y = child.y
+		while child.parent != root_node do
+			y += child.parent.y
+			child = child.parent
+		end
+		return y
+	end
 
-  local function scroll_to_child(child)
-    local scroll_root_node = -child_y_relative_to_root_node(child) + (el.height / 2)
-    if scroll_root_node > 0 then
-      scroll_root_node = 0
-    end
-    local max_scroll = -root_node.height + el.height
-    if scroll_root_node <= max_scroll then
-      scroll_root_node = max_scroll
-    end
+	local function scroll_to_child(child)
+		local scroll_root_node = -child_y_relative_to_root_node(child) + (el.height / 2)
+		if scroll_root_node > 0 then
+			scroll_root_node = 0
+		end
+		local max_scroll = -root_node.height + el.height
+		if scroll_root_node <= max_scroll then
+			scroll_root_node = max_scroll
+		end
 
-    root_node.y = scroll_root_node
-  end
+		root_node.y = scroll_root_node
+	end
 
-  function container:select_child(id)
-    selected_child = nodes_by_id[id]
-    scroll_to_child(selected_child)
-  end
+	function container:select_child(id)
+		selected_child = nodes_by_id[id]
+		scroll_to_child(selected_child)
+	end
 
-  return container
+	return container
 end

--- a/runner.lua
+++ b/runner.lua
@@ -10,7 +10,7 @@ local parent_pid = env().parent_pid
 local test_file = env().argv[1]
 local dir_in_file = string.match(test_file, ".+/")
 if dir_in_file then
-    work_dir = dir_in_file
+	work_dir = dir_in_file
 end
 
 -- TODO Do not pass run_tests function to test script in _ENV
@@ -21,82 +21,81 @@ local id_sequence = 0
 local tests = {} -- {id=1,name=..}
 
 local function set_error_on_parents(parent, err)
-    while parent != nil do
-        parent.error = err
-        parent = parent.parent
-    end
+	while parent != nil do
+		parent.error = err
+		parent = parent.parent
+	end
 end
 
 ---Starts a test with given name and code
 ---@param name any Name of test
 ---@param test function Test code
 function test(name, test)
-    local parent
-    if #tests > 0 then
-        parent = tests[#tests]
-    end
+	local parent
+	if #tests > 0 then
+		parent = tests[#tests]
+	end
 
-    id_sequence += 1
-    local current_test = { 
-        id = id_sequence,
-        name = tostring(name),
-        parent = parent,
-    }
-    table.insert(tests, current_test)
+	id_sequence += 1
+	local current_test = {
+		id = id_sequence,
+		name = tostring(name),
+		parent = parent,
+	}
+	table.insert(tests, current_test)
 
-    send_message(parent_pid, { event = "test_started", test = current_test })
+	send_message(parent_pid, { event = "test_started", test = current_test })
 
-    local success, err = pcall(test)
-    if not success then
-        if type(err) == "string" then
-            local escaped_work_dir = work_dir:gsub("([%W])", "%%%1")
-            local file = "" 
-            local msg = err
-            if string.match(err, escaped_work_dir) then
-                file = string.gsub(err, "(%d+):.*", "%1") -- drop message 
-                msg = string.gsub(err, file..": ", "")
-            end
-            err = {
-                assert = "generic",
-                original_error = err,
-                file = file,
-                msg = msg, 
-            }
-        end
+	local success, err = pcall(test)
+	if not success then
+		if type(err) == "string" then
+			local escaped_work_dir = work_dir:gsub("([%W])", "%%%1")
+			local file = ""
+			local msg = err
+			if string.match(err, escaped_work_dir) then
+				file = string.gsub(err, "(%d+):.*", "%1") -- drop message
+				msg = string.gsub(err, file .. ": ", "")
+			end
+			err = {
+				assert = "generic",
+				original_error = err,
+				file = file,
+				msg = msg,
+			}
+		end
 
-        set_error_on_parents(parent, "nested test failed")        
-    end
+		set_error_on_parents(parent, "nested test failed")
+	end
 
-    if err == nil then
-        err = current_test.error
-    end
+	if err == nil then
+		err = current_test.error
+	end
 
-    table.remove(tests, #tests)
+	table.remove(tests, #tests)
 
-    send_message(parent_pid,
-        { event = "test_finished", test = current_test, error = err })
-
+	send_message(parent_pid,
+		{ event = "test_finished", test = current_test, error = err })
 end
 
 local originalPrint = print
 
 -- override picotron print, so all text is sent to the parent process
 function print(text, x, y, color)
-    if x == nil and y == nil and color == nil then
-        send_message(parent_pid, { event = "print", test = tests[#tests], text = text })
-    end
+	if x == nil and y == nil and color == nil then
+		send_message(parent_pid, { event = "print", test = tests[#tests], text = text })
+	end
 
-    originalPrint(text, x, y, color)
+	originalPrint(text, x, y, color)
 end
 
 cd(work_dir)
 
 test("root", function()
-    local ok = include(test_file)
-    if not ok then
-        send_message(parent_pid, { event = "fatal_error", error = test_file .. " not found" })
-        return
-    end
+	local ok = include(test_file)
+	if not ok then
+		send_message(parent_pid, { event = "fatal_error", error = test_file .. " not found" })
+		return
+	end
 end)
 
 send_message(parent_pid, { event = "done", root_test_id = 1 })

--- a/tests/api_test.lua
+++ b/tests/api_test.lua
@@ -5,95 +5,95 @@ include "test.lua"
 include "../api.lua"
 
 test("assert_eq", function()
-    test("should fail when not equal", function()
-        local tests = {
-            numbers = {
-                left = 10, right = 11,
-            },
-            strings = {
-                left = "a", right = "b",
-            },
-            flat_tables = {
-                left = { key = "value" },
-                right = { key = "different_value" },
-            },
-            tables_with_different_number_of_keys = {
-                left = { key = "value"},
-                right = { key = "value", another_key = "another_value"},
-            },
-            nested_tables = {
-                left = { a = { b = "c" } },
-                right = { a = { b = "d" } },
-            },
-            different_types = {
-                left = "1", right = 1,
-            },
-            userdata_different_width = {
-                left  = userdata("u8", 2, 1),
-                right = userdata("u8", 1, 1),
-            },
-            userdata_different_height = {
-                left  = userdata("u8", 1, 2),
-                right = userdata("u8", 1, 1),
-            },
-            userdata_different_values = {
-                left = userdata('u8', 2, 2, "02030405"),
-                right = userdata('u8', 2, 2, "0A0B0C0D"),
-            },
-            userdata_different_type = {
-                left = userdata('u8', 2, 2),
-                right = userdata('i32', 2, 2),
-            },
-        }
+	test("should fail when not equal", function()
+		local tests = {
+			numbers = {
+				left = 10, right = 11,
+			},
+			strings = {
+				left = "a", right = "b",
+			},
+			flat_tables = {
+				left = { key = "value" },
+				right = { key = "different_value" },
+			},
+			tables_with_different_number_of_keys = {
+				left = { key = "value" },
+				right = { key = "value", another_key = "another_value" },
+			},
+			nested_tables = {
+				left = { a = { b = "c" } },
+				right = { a = { b = "d" } },
+			},
+			different_types = {
+				left = "1", right = 1,
+			},
+			userdata_different_width = {
+				left  = userdata("u8", 2, 1),
+				right = userdata("u8", 1, 1),
+			},
+			userdata_different_height = {
+				left  = userdata("u8", 1, 2),
+				right = userdata("u8", 1, 1),
+			},
+			userdata_different_values = {
+				left = userdata('u8', 2, 2, "02030405"),
+				right = userdata('u8', 2, 2, "0A0B0C0D"),
+			},
+			userdata_different_type = {
+				left = userdata('u8', 2, 2),
+				right = userdata('i32', 2, 2),
+			},
+		}
 
-        for test_name, case in pairs(tests) do
-            test(test_name, function()
-                local success = pcall(assert_eq, case.left, case.right)
-                assert(not success)
-            end)
-        end
-    end)
+		for test_name, case in pairs(tests) do
+			test(test_name, function()
+				local success = pcall(assert_eq, case.left, case.right)
+				assert(not success)
+			end)
+		end
+	end)
 
-    test("should not fail when equal", function()
-        local table_with_cycle = {}
-        table_with_cycle.next = table_with_cycle 
+	test("should not fail when equal", function()
+		local table_with_cycle = {}
+		table_with_cycle.next = table_with_cycle
 
-        local another_table_with_cycle = {}
-        another_table_with_cycle.next = another_table_with_cycle 
+		local another_table_with_cycle = {}
+		another_table_with_cycle.next = another_table_with_cycle
 
-        local tests = {
-            numbers = {
-                left = 10, right = 10,
-            },
-            strings = {
-                left = "a", right = "a",
-            },
-            flat_tables = {
-                left = { key = "value" },
-                right = { key = "value" },
-            },
-            nested_tables = {
-                left = { a = { b = "c" } },
-                right = { a = { b = "c" } },
-            },
-            tables_with_nil_value = { -- in Lua there is no distinction whether key is nil or not present in a table
-                left = { key = nil }, 
-                right = { another_key = nil}, 
-            },
-            tables_with_cycle = {
-                left = table_with_cycle,
-                right = another_table_with_cycle,
-            },
-            userdata = {
-                left = userdata('u8', 2, 2, "02030405"),
-                right = userdata('u8', 2, 2, "02030405"),
-            },
-        }
+		local tests = {
+			numbers = {
+				left = 10, right = 10,
+			},
+			strings = {
+				left = "a", right = "a",
+			},
+			flat_tables = {
+				left = { key = "value" },
+				right = { key = "value" },
+			},
+			nested_tables = {
+				left = { a = { b = "c" } },
+				right = { a = { b = "c" } },
+			},
+			tables_with_nil_value = { -- in Lua there is no distinction whether key is nil or not present in a table
+				left = { key = nil },
+				right = { another_key = nil },
+			},
+			tables_with_cycle = {
+				left = table_with_cycle,
+				right = another_table_with_cycle,
+			},
+			userdata = {
+				left = userdata('u8', 2, 2, "02030405"),
+				right = userdata('u8', 2, 2, "02030405"),
+			},
+		}
 
-        for test_name, case in pairs(tests) do
-            test(test_name, function()
-                assert_eq(case.left, case.right)
-            end)
-        end
-    end)
+		for test_name, case in pairs(tests) do
+			test(test_name, function()
+				assert_eq(case.left, case.right)
+			end)
+		end
+	end)
 end)

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -2,15 +2,15 @@
 -- This code is licensed under MIT license (see LICENSE for details)
 
 -- this file contains functions used in tests veryfing unitron behavior
--- functions here are extremely simple compared to unitron (no custom assertions, 
+-- functions here are extremely simple compared to unitron (no custom assertions,
 -- no spawning background processes etc.)
 
 local level = 0
 
 function test(name, func)
-    local space = " "
-    print(space:rep(level) .. "Running " .. name)
-    level += 1
-    func()
-    level -= 1
+	local space = " "
+	print(space:rep(level) .. "Running " .. name)
+	level += 1
+	func()
+	level -= 1
 end


### PR DESCRIPTION
When there is an assertion error, user can click on the file name in the test output. This will open Lua editor with the file at error location.
