### PR TITLE
Throttle test execution when tests are too fast

### DIFF
--- a/runner.lua
+++ b/runner.lua
@@ -9,6 +9,7 @@
 -- runner send messages with events to communicate with the parent process.
 
 include "api.lua"
+include "throttler.lua"
 
 local work_dir            = env().path
 
@@ -24,9 +25,12 @@ end
 
 local id_sequence = 0
 
-local tests <const> = {} -- {id=1,name=..}
+local tests <const> = {}                            -- {id=1,name=..}
+
+local publish_throttler <const> = new_throttler(50) -- max 50 messages per frame
 
 local function publish(msg)
+	publish_throttler:throttle()
 	send_message(parent_pid, msg)
 end
 

--- a/runner.lua
+++ b/runner.lua
@@ -10,11 +10,11 @@
 
 include "api.lua"
 
-local work_dir = env().path
+local work_dir            = env().path
 
-local parent_pid = env().parent_pid
-local test_file = env().argv[1]
-local dir_in_file = string.match(test_file, ".+/")
+local parent_pid <const>  = env().parent_pid
+local test_file <const>   = env().argv[1]
+local dir_in_file <const> = string.match(test_file, ".+/")
 if dir_in_file then
 	work_dir = dir_in_file
 end
@@ -24,7 +24,7 @@ end
 
 local id_sequence = 0
 
-local tests = {} -- {id=1,name=..}
+local tests <const> = {} -- {id=1,name=..}
 
 local function set_error_on_parents(parent, err)
 	while parent != nil do
@@ -86,7 +86,7 @@ function test(name, test)
 		{ event = "test_finished", test = current_test, error = err })
 end
 
-local originalPrint = print
+local originalPrint <const> = print
 
 -- override picotron print, so all text is sent to the parent process
 function print(text, x, y, color)

--- a/throttler.lua
+++ b/throttler.lua
@@ -1,0 +1,32 @@
+-- (c) 2024 Jacek Olszak
+-- This code is licensed under MIT license (see LICENSE for details)
+
+-- creates an object which slows down the code if it runs too fast
+function new_throttler(max_per_frame)
+   local fps <const> = 60
+   local instructions_per_second = 8000000 -- max no of instructions in Picotron
+
+   local started, count
+
+   local function reset()
+      started = time()
+      count = 0
+   end
+
+   reset()
+
+   local throttler <const> = {}
+
+   function throttler:throttle()
+      count += 1
+      if count > max_per_frame and
+          count / (time() - started) / fps > max_per_frame
+      then
+         -- sleep for a frame
+         for i = 1, instructions_per_second / fps do end
+         reset()
+      end
+   end
+
+   return throttler
+end


### PR DESCRIPTION
Large number (hundreds and more) of extremely fast tests could block the
UI. To avoid that, measure how fast tests are. If they are too fast and
the number of tests is significant then slow them down by sleeping.