### PR TITLE
Increase performance of presenting test output

### DIFF
--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -4,7 +4,7 @@
 -- this file contains code controlling GUI of test runner
 
 include "gui/tree.lua"
-include "gui/textarea.lua"
+include "gui/text_output.lua"
 include "gui/lights.lua"
 include "gui/test_summary.lua"
 include "gui/test_toolbar.lua"
@@ -54,7 +54,7 @@ local function start_test(item)
 		return text:match("[^ ]*%.lua:%d+")
 	end
 
-	local textarea = attach_textarea(
+	local text_output = attach_text_output(
 		gui,
 		{
 			x = 0,
@@ -96,7 +96,7 @@ local function start_test(item)
 	local function select_test(test_id)
 		selected_test_id = test_id
 
-		textarea:scroll_to_the_top()
+		text_output:scroll_to_the_top()
 
 		lights:detach()
 		test_summary:detach()

--- a/gui/printed_lines.lua
+++ b/gui/printed_lines.lua
@@ -14,12 +14,20 @@ function new_printed_lines()
       table.insert(by_test_id[test_id], text)
    end
 
-   function printed_lines:lines(test_id)
+   function printed_lines:line(test_id, line_no)
       if by_test_id[test_id] == nil then
-         return {}
+         return ""
       end
 
-      return by_test_id[test_id]
+      return by_test_id[test_id][line_no] or ""
+   end
+
+   function printed_lines:lines_len(test_id, line_no)
+      if by_test_id[test_id] == nil then
+         return 0
+      end
+
+      return #by_test_id[test_id] or 0
    end
 
    function printed_lines:reset()

--- a/gui/text_output.lua
+++ b/gui/text_output.lua
@@ -2,13 +2,13 @@
 -- This code is licensed under MIT license (see LICENSE for details)
 
 ---@param el {x:number, y:number, width:number, height:number, is_link:function, link_click:function, get_line:function, lines_len:function}
-function attach_textarea(parent, el)
+function attach_text_output(parent, el)
 	local line_height <const> = 10
 
 	local lines_len = 0
 
 	el = parent:attach(el)
-	local text_area <const> = el:attach(
+	local text_output <const> = el:attach(
 		{ x = 0, y = 0, width = el.width, height = 0 }
 	)
 	el:attach_scrollbars { autohide = true }
@@ -21,7 +21,7 @@ function attach_textarea(parent, el)
 		return line_no < lines_len and el.is_link != nil and el.is_link(line_no)
 	end
 
-	function text_area:update(msg)
+	function text_output:update(msg)
 		lines_len = el.lines_len()
 		if msg.my == nil then return end -- outside the window
 		local cursor = ""
@@ -29,10 +29,10 @@ function attach_textarea(parent, el)
 		if is_link(line) then
 			cursor = "pointer"
 		end
-		text_area.cursor = cursor
+		text_output.cursor = cursor
 	end
 
-	function text_area:click(msg)
+	function text_output:click(msg)
 		local line = line_at_mouse_position(msg)
 		if is_link(line) and el.link_click != nil then
 			el.link_click(line)
@@ -40,10 +40,10 @@ function attach_textarea(parent, el)
 	end
 
 	-- for performance reasons draw only visible lines
-	function text_area:draw()
-		local line_no = flr(-text_area.y / line_height)
+	function text_output:draw()
+		local line_no = flr(-text_output.y / line_height)
 
-		text_area.height = line_height * lines_len
+		text_output.height = line_height * lines_len
 
 		local last_line = line_no + ceil(el.height / line_height)
 		last_line = min(last_line, lines_len - 1)
@@ -54,12 +54,12 @@ function attach_textarea(parent, el)
 		end
 	end
 
-	function text_area:mousewheel(e)
+	function text_output:mousewheel(e)
 		self.y += e.wheel_y * 32
 	end
 
 	function el:scroll_to_the_top()
-		text_area.y = 0
+		text_output.y = 0
 	end
 
 	return el


### PR DESCRIPTION
Test results component is slow when number of lines is in hundreds or more.

With this change:
* the CPU overhead ofpresenting test output is orders of magnitude lower
* also the memory consumption is reduced significantly