### PR TITLE
Optimize performance of results tree

### DIFF
--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -3,12 +3,12 @@
 
 -- this file contains code controlling GUI of test runner
 
-include "gui/tree.lua"
 include "gui/text_output.lua"
 include "gui/lights.lua"
 include "gui/test_summary.lua"
 include "gui/test_toolbar.lua"
 include "gui/printed_lines.lua"
+include "gui/tree.lua"
 
 local width <const> = 280
 local height <const> = 200
@@ -65,12 +65,17 @@ local function start_test(item)
 			y = 97,
 			width = width,
 			height = 103,
+			bg_color = 0,
 			lines_len = function()
 				if selected_test_id == nil then return 0 end
 				return printed_lines:lines_len(selected_test_id)
 			end,
 			get_line = function(line_no)
-				return printed_lines:line(selected_test_id, line_no)
+				return {
+					text = printed_lines:line(selected_test_id, line_no),
+					bg_color = 0,
+					fg_color = 7,
+				}
 			end,
 			is_link = function(line_no)
 				local text = printed_lines:line(selected_test_id, line_no)
@@ -100,7 +105,7 @@ local function start_test(item)
 	local function select_test(test_id)
 		selected_test_id = test_id
 
-		text_output:scroll_to_the_top()
+		text_output:scroll_to_line(1)
 
 		lights:detach()
 		test_summary:detach()
@@ -122,11 +127,14 @@ local function start_test(item)
 
 	test_tree = attach_tree(
 		gui,
-		{ x = 0, y = 16, width = width, height = 80 }
+		{
+			x = 0,
+			y = 16,
+			width = width,
+			height = 80,
+			select = select_test
+		}
 	)
-	function test_tree:select(e)
-		select_test(e.id)
-	end
 
 	attach_toolbar(
 		gui,
@@ -328,5 +336,8 @@ function _draw()
 	if gui != nil then
 		cls()
 		gui:draw_all()
+		-- debug fps and memory usage:
+		-- print(stat(7), 250, 0, 1)
+		-- print(stat(0), 220, 10, 1)
 	end
 end

--- a/gui/text_output.lua
+++ b/gui/text_output.lua
@@ -1,7 +1,7 @@
 -- (c) 2024 Jacek Olszak
 -- This code is licensed under MIT license (see LICENSE for details)
 
----@param el {x:number, y:number, width:number, height:number, is_link:function, link_click:function, get_line:function, lines_len:function}
+---@param el {x:number, y:number, width:number, height:number, bg_color:integer, is_link:function, link_click:function, get_line:function, lines_len:function}
 function attach_text_output(parent, el)
 	local line_height <const> = 10
 
@@ -51,7 +51,10 @@ function attach_text_output(parent, el)
 
 		for i = line_no, last_line do
 			local line = el.get_line(i + 1)
-			print(line, 0, i * line_height, 7)
+			rectfill(0, i * line_height,
+				text_output.width, (i + 1) * line_height + 1,
+				line.bg_color)
+			print(line.text, 1, i * line_height + 1, line.fg_color)
 		end
 	end
 
@@ -59,11 +62,21 @@ function attach_text_output(parent, el)
 		self.y += e.wheel_y * 32
 	end
 
-	function el:scroll_to_the_top()
-		text_output.y = 0
+	function el:scroll_to_line(line_no)
+		text_output.y = -(line_height * (line_no - 1))
+		if text_output.y == 0 then
+			return
+		end
+		text_output.y += el.height / 2 - line_height
+		if -text_output.y + el.height > text_output.height then
+			text_output.y = -text_output.height + el.height
+		end
 	end
 
-	function el:draw() end
+	function el:draw()
+		-- draw background (needed when tree height is too low)
+		rectfill(0, 0, el.width, el.height, el.bg_color)
+	end
 
 	return el
 end

--- a/gui/text_output.lua
+++ b/gui/text_output.lua
@@ -63,5 +63,7 @@ function attach_text_output(parent, el)
 		text_output.y = 0
 	end
 
+	function el:draw() end
+
 	return el
 end

--- a/gui/text_output.lua
+++ b/gui/text_output.lua
@@ -58,10 +58,6 @@ function attach_text_output(parent, el)
 		end
 	end
 
-	function text_output:mousewheel(e)
-		self.y += e.wheel_y * 32
-	end
-
 	function el:scroll_to_line(line_no)
 		text_output.y = -(line_height * (line_no - 1))
 		if text_output.y == 0 then

--- a/gui/text_output.lua
+++ b/gui/text_output.lua
@@ -18,7 +18,8 @@ function attach_text_output(parent, el)
 	end
 
 	local function is_link(line_no)
-		return line_no < lines_len and el.is_link != nil and el.is_link(line_no)
+		return line_no >= 1 and line_no <= lines_len
+			 and el.is_link != nil and el.is_link(line_no)
 	end
 
 	function text_output:update(msg)

--- a/gui/tree_provider.lua
+++ b/gui/tree_provider.lua
@@ -1,0 +1,48 @@
+-- (c) 2024 Jacek Olszak
+-- This code is licensed under MIT license (see LICENSE for details)
+
+--- returns a new instance of data structure holding tree of nodes. This object
+--- is used by tree component. The code was extracted from the tree component
+--- because the component was to complex (and will be even more complex
+--- when tree will have node collapsing and hiding functionality).
+function new_tree_provider()
+   local p = {}
+
+   local nodes_by_line <const> = {}
+   local nodes_by_id <const> = {}
+
+   function p:nodes_len()
+      return #nodes_by_line
+   end
+
+   function p:get_node(line_no)
+      return nodes_by_line[line_no]
+   end
+
+   function p:get_line_no(id)
+      for line_no, node in ipairs(nodes_by_line) do
+         if node.id == id then
+            return line_no
+         end
+      end
+
+      return nil
+   end
+
+   function p:append_node(parent_id, id, text)
+      local node = { text = text, depth = 0, id = id, has_children = false }
+      if parent_id != nil then
+         local parent = nodes_by_id[parent_id]
+         parent.has_children = true
+         node.depth = parent.depth + 1
+      end
+      nodes_by_id[node.id] = node
+      table.insert(nodes_by_line, node)
+   end
+
+   function p:update_node_text(id, new_text)
+      nodes_by_id[id].text = new_text
+   end
+
+   return p
+end

--- a/gui/tree_provider_test.lua
+++ b/gui/tree_provider_test.lua
@@ -1,0 +1,39 @@
+-- (c) 2024 Jacek Olszak
+-- This code is licensed under MIT license (see LICENSE for details)
+
+include "tree_provider.lua"
+
+test("new provider has 0 lines", function()
+   local p = new_tree_provider()
+   assert_eq(0, p:nodes_len())
+end)
+
+test("add root", function()
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+   assert_eq(1, p:nodes_len())
+   assert_eq({ text = "root", depth = 0, id = 1, has_children = false }, p:get_node(1))
+   assert_eq(1, p:get_line_no(1))
+end)
+
+test("add child node", function()
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+   -- when
+   p:append_node(1, 2, "child")
+   -- then
+   assert_eq(2, p:nodes_len())
+   assert_eq({ text = "child", depth = 1, id = 2, has_children = false }, p:get_node(2))
+   assert_eq(2, p:get_line_no(2))
+   -- and
+   assert(p:get_node(1).has_children)
+end)
+
+test("update node text", function()
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+   -- when
+   p:update_node_text(1, "updated")
+   -- then
+   assert_eq("updated", p:get_node(1).text)
+end)


### PR DESCRIPTION
The GUI is very slow when the number of tests exceeds 500. The reason for this is the tree component that displays the test names. Its implementation is inefficient. In each frame, this component draws all its content - even those invisible to the user. 

This PR changes the implementation of the tree component to a more efficient one. The new implementation only draws the part of the tree that is currently presented to the user. This component also uses a minimal amount of RAM, which allows you to run several thousand tests.