### PR TITLE
Add collapsing/expanding of tree nodes

### DIFF
--- a/gui/text_output.lua
+++ b/gui/text_output.lua
@@ -24,6 +24,14 @@ function attach_text_output(parent, el)
 
 	function text_output:update(msg)
 		lines_len = el.lines_len()
+
+		text_output.height = line_height * lines_len
+
+		-- If text_output has decreased, adjust the y position.
+		if text_output.height - el.height < -text_output.y then
+			text_output.y = min(-text_output.height + el.height, 0) -- test this
+		end
+
 		if msg.my == nil then return end -- outside the window
 		local cursor = ""
 		local line = line_at_mouse_position(msg)
@@ -43,8 +51,6 @@ function attach_text_output(parent, el)
 	-- for performance reasons draw only visible lines
 	function text_output:draw()
 		local line_no = flr(-text_output.y / line_height)
-
-		text_output.height = line_height * lines_len
 
 		local last_line = line_no + ceil(el.height / line_height)
 		last_line = min(last_line, lines_len - 1)

--- a/gui/tree.lua
+++ b/gui/tree.lua
@@ -4,9 +4,16 @@
 function attach_tree(parent_el, el)
 	include "gui/tree_provider.lua"
 
+	local char_width <const> = 5
+
 	local provider <const> = new_tree_provider()
 
 	local selected_line = nil
+
+	-- return indent of node in chars
+	local function indent(node)
+		return node.depth * 2
+	end
 
 	local tree = attach_text_output(parent_el, {
 		x = el.x,
@@ -25,9 +32,13 @@ function attach_tree(parent_el, el)
 				bg_color = 1
 			end
 
-			local prefix = whitespace:rep(node.depth * 2)
+			local prefix = whitespace:rep(indent(node))
 			if node.has_children then
-				prefix = prefix .. "[-] "
+				if not node.collapsed then
+					prefix = prefix .. "[-] "
+				else
+					prefix = prefix .. "[+] "
+				end
 			else
 				prefix = prefix .. "    "
 			end
@@ -44,8 +55,14 @@ function attach_tree(parent_el, el)
 			return true
 		end,
 		link_click = function(line_no, msg)
+			local node = provider:get_node(line_no)
+			if node.has_children and
+				 msg.mx >= indent(node) * char_width and
+				 msg.mx <= (indent(node) + 3) * char_width then
+				provider:toggle_line(line_no)
+			end
 			selected_line = line_no
-			el.select(provider:get_node(line_no).id)
+			el.select(node.id)
 		end,
 		lines_len = function()
 			return provider:nodes_len()

--- a/gui/tree_provider.lua
+++ b/gui/tree_provider.lua
@@ -6,10 +6,11 @@
 --- because the component was to complex (and will be even more complex
 --- when tree will have node collapsing and hiding functionality).
 function new_tree_provider()
-   local p = {}
+   local p                                     = {}
 
-   local nodes_by_line <const> = {}
-   local nodes_by_id <const> = {}
+   local nodes_by_line                         = {}
+   local nodes_by_id <const>                   = {}
+   local collapsed_children_by_node_id <const> = {}
 
    function p:nodes_len()
       return #nodes_by_line
@@ -29,15 +30,76 @@ function new_tree_provider()
       return nil
    end
 
+   local function collapse(line_no, node)
+      local first_line_no = line_no + 1
+      local last_line_no = line_no
+      for i = first_line_no, #nodes_by_line do
+         local potential_child = nodes_by_line[i]
+         if potential_child.depth <= node.depth then
+            break
+         end
+         last_line_no = i
+      end
+
+      collapsed_children_by_node_id[node.id] = {}
+      nodes_by_line = move_table(
+         nodes_by_line, first_line_no, last_line_no,
+         collapsed_children_by_node_id[node.id], 1)
+   end
+
+   local function expand(line_no, node)
+      local src = collapsed_children_by_node_id[node.id]
+      insert_table(src, line_no + 1, nodes_by_line)
+
+      collapsed_children_by_node_id[node.id] = nil
+   end
+
+   function p:toggle_line(line_no)
+      local node <const> = nodes_by_line[line_no]
+      if node.collapsed then
+         expand(line_no, node)
+      else
+         collapse(line_no, node)
+      end
+      node.collapsed = not node.collapsed
+   end
+
+   -- append node to the end of the tree
    function p:append_node(parent_id, id, text)
-      local node = { text = text, depth = 0, id = id, has_children = false }
+      local node = {
+         text = text,
+         depth = 0,
+         parent_id = parent_id,
+         id = id,
+         has_children = false,
+         collapsed = false
+      }
+      local parent = nil
       if parent_id != nil then
-         local parent = nodes_by_id[parent_id]
+         parent = nodes_by_id[parent_id]
          parent.has_children = true
          node.depth = parent.depth + 1
       end
       nodes_by_id[node.id] = node
-      table.insert(nodes_by_line, node)
+
+      local function find_collpased_node(n)
+         if n == nil then
+            return nil
+         end
+         if n.collapsed then
+            return n
+         end
+         return find_collpased_node(nodes_by_id[n.parent_id])
+      end
+
+      local collapsed_parent = find_collpased_node(parent)
+
+      if collapsed_parent == nil then
+         table.insert(nodes_by_line, node)
+      else
+         local children = collapsed_children_by_node_id[collapsed_parent.id]
+         table.insert(children, node)
+      end
    end
 
    function p:update_node_text(id, new_text)

--- a/gui/tree_provider_test.lua
+++ b/gui/tree_provider_test.lua
@@ -4,6 +4,7 @@
 -- run this file in unitron gui
 
 include "tree_provider.lua"
+include "../lib/tables.lua" -- TODO ugly way of importing dependencies
 
 test("new provider has 0 lines", function()
    local p = new_tree_provider()
@@ -14,7 +15,16 @@ test("add root", function()
    local p = new_tree_provider()
    p:append_node(nil, 1, "root")
    assert_eq(1, p:nodes_len())
-   assert_eq({ text = "root", depth = 0, id = 1, has_children = false }, p:get_node(1))
+   assert_eq(
+      {
+         text = "root",
+         depth = 0,
+         id = 1,
+         has_children = false,
+         collapsed = false
+      },
+      p:get_node(1)
+   )
    assert_eq(1, p:get_line_no(1))
 end)
 
@@ -25,7 +35,17 @@ test("add child node", function()
    p:append_node(1, 2, "child")
    -- then
    assert_eq(2, p:nodes_len())
-   assert_eq({ text = "child", depth = 1, id = 2, has_children = false }, p:get_node(2))
+   assert_eq(
+      {
+         text = "child",
+         depth = 1,
+         id = 2,
+         parent_id = 1,
+         has_children = false,
+         collapsed = false
+      },
+      p:get_node(2)
+   )
    assert_eq(2, p:get_line_no(2))
    -- and
    assert(p:get_node(1).has_children)
@@ -38,4 +58,88 @@ test("update node text", function()
    p:update_node_text(1, "updated")
    -- then
    assert_eq("updated", p:get_node(1).text)
+end)
+
+test("toggle_line", function()
+   test("should collapse node", function()
+      local p = new_tree_provider()
+      p:append_node(nil, 1, "root")
+      p:append_node(1, 2, "child")
+      p:append_node(2, 3, "subchild")
+      -- when
+      p:toggle_line(1)
+      -- then
+      assert(p:get_node(1).collapsed)
+      assert_eq(1, p:nodes_len())
+
+      test("should expand node", function()
+         -- when
+         p:toggle_line(1)
+         -- then
+         assert(not p:get_node(1).collapsed)
+         assert_eq(3, p:nodes_len())
+         assert_eq("child", p:get_node(2).text)
+         assert_eq("subchild", p:get_node(3).text)
+      end)
+   end)
+end)
+
+test("append_node when parent node is collapsed", function()
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+   p:toggle_line(1) -- collapse root
+   -- when
+   p:append_node(1, 2, "child")
+   -- then
+   assert(p:nodes_len() == 1, "child should not be visible")
+end)
+
+test("append_node when parent of parent is collapsed", function()
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+   p:append_node(1, 2, "child")
+   p:toggle_line(1) -- collapse root
+   -- when
+   p:append_node(2, 3, "subchild")
+   -- then
+   assert(p:nodes_len() == 1, "subchild should not be visible")
+end)
+
+test("expand when node added when parent was collapsed", function()
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+   p:toggle_line(1) -- collapse root
+   p:append_node(1, 2, "child")
+   -- when
+   p:toggle_line(1) -- expand root
+   assert_eq(2, p:nodes_len(), "two elements expected")
+end)
+
+test("expand node after another child was added", function()
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+   p:append_node(1, 2, "child") -- line 2
+   p:append_node(2, 3, "subchild")
+   p:toggle_line(2)             -- collapse child
+   p:append_node(1, 4, "another child")
+   assert_eq(3, p:nodes_len())
+   p:toggle_line(2) -- expand child
+   assert_eq(4, p:nodes_len())
+end)
+
+test("thousands of children", function()
+   -- should finish in a second
+   local p = new_tree_provider()
+   p:append_node(nil, 1, "root")
+
+   test("append_node", function()
+      for id = 2, 10000 do
+         p:append_node(1, id, "child")
+      end
+   end)
+
+   test("toggle_line", function()
+      p:toggle_line(1)
+      p:toggle_line(1)
+   end)
 end)

--- a/lib/tables.lua
+++ b/lib/tables.lua
@@ -1,0 +1,32 @@
+-- (c) 2024 Jacek Olszak
+-- This code is licensed under MIT license (see LICENSE for details)
+
+---@param from table
+---@param pos integer
+---@param to table
+function insert_table(from, pos, to)
+   table.move(to,
+      pos, pos + (#to - pos),
+      #from + pos)
+
+   table.move(from, 1, #from, pos, to)
+end
+
+---Moves all elements from one table to another. Returns new table with removed
+---elements
+---@param from_table table
+---@param from_first integer
+---@param from_last integer
+---@param to_table table
+---@param to_first integer
+function move_table(from_table, from_first, from_last, to_table, to_first)
+   local results = {}
+
+   table.move(from_table, from_first, from_last, to_first, to_table)
+
+   table.move(from_table, 1, from_first - 1, 1, results)
+   table.move(from_table, from_last + 1, #from_table,
+      from_first, results)
+
+   return results
+end

--- a/lib/tables_test.lua
+++ b/lib/tables_test.lua
@@ -1,0 +1,20 @@
+-- (c) 2024 Jacek Olszak
+-- This code is licensed under MIT license (see LICENSE for details)
+
+include "tables.lua"
+
+test("insert_table", function()
+   local from = { 1, 2, 3 }
+   local to = { 'A', 'B', 'C' }
+   local pos = 2
+   insert_table(from, pos, to)
+   assert_eq({ 'A', 1, 2, 3, 'B', 'C' }, to)
+end)
+
+test("move_table", function()
+   local from = { 1, 2, 3 }
+   local to = { 'A', 'B', 'C' }
+   local result = move_table(from, 2, 3, to, 2)
+   assert_eq({ 'A', 2, 3 }, to)
+   assert_eq({ 1 }, result)
+end)

--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,8 @@
 -- (c) 2024 Jacek Olszak
 -- This code is licensed under MIT license (see LICENSE for details)
 
+include "lib/tables.lua"
+
 if #env().argv == 0 then
 	include "gui/gui.lua"
 else

--- a/runner.lua
+++ b/runner.lua
@@ -95,7 +95,7 @@ local originalPrint <const> = print
 -- override picotron print, so all text is sent to the parent process
 function print(text, x, y, color)
 	if x == nil and y == nil and color == nil then
-		publish { event = "print", test = tests[#tests], text = text }
+		publish { event = "print", test = tests[#tests], text = tostring(text) }
 	end
 
 	originalPrint(text, x, y, color)


### PR DESCRIPTION
This new feature allows user to collapse (and then expand) the result tree node which has children.

![video_3](https://github.com/user-attachments/assets/15b190ce-9978-40ba-9150-86b313ec31cd)
