### PR TITLE
[bugfix] "]" character is escaped in assert_eq/assert_not_eq arguments

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -85,18 +85,18 @@ end
 
 local function serialize_arg(v)
 	if v == nil then
-		return
+		return nil
 	end
 	local serialized = pod(v)
 	if serialized == nil then
 		if type(v) == "table" then
 			return "[cyclic table]"
-		else
-			return "[not serializable]"
 		end
+		return "[not serializable]"
 	end
 
-	return serialized
+	-- no need to escape ] because meta data is not serialized:
+	return serialized:gsub("\\093", "]") -- TODO unescape all special characters
 end
 
 local function serialize_message(msg)

--- a/api.lua
+++ b/api.lua
@@ -150,6 +150,16 @@ function assert_not_eq(not_expected, actual, msg)
 	end
 end
 
+-- converts v to string optionally adding quotes
+local function as_string(v)
+	local s = tostring(v)
+	if type(v) == "string" then
+		-- append quotes in order to distinguish string from number
+		s = string.format('"%s"', s)
+	end
+	return s
+end
+
 ---@param expected any
 ---@param actual any
 ---@param msg? any message which will be presented in the unitron ui.
@@ -157,10 +167,8 @@ function assert_same(expected, actual, msg)
 	if expected != actual then
 		local err = {
 			assert = "same",
-			-- tostring() is more useful than serialize because pointers have
-			-- more value than values here:
-			expected = tostring(expected),
-			actual = tostring(actual),
+			expected = as_string(expected),
+			actual = as_string(actual),
 			msg = serialize_message(msg),
 			file = get_caller(),
 		}
@@ -175,7 +183,7 @@ function assert_not_same(not_expected, actual, msg)
 	if not_expected == actual then
 		local err = {
 			assert = "not_same",
-			actual = tostring(actual),
+			actual = as_string(actual),
 			msg = serialize_message(msg),
 			file = get_caller(),
 		}
@@ -192,9 +200,9 @@ function assert_close(expected, actual, delta, msg)
 	if invalid_args or abs(expected - actual) > delta then
 		local err = {
 			assert = "close",
-			expected = tostring(expected), -- TODO Picotron has a bug that small numbers are not properly serialized
-			actual = tostring(actual), -- TODO Picotron has a bug that small numbers are not properly serialized
-			delta = tostring(delta), -- TODO Picotron has a bug that small numbers are not properly serialized
+			expected = as_string(expected), -- TODO Picotron has a bug that small numbers are not properly serialized
+			actual = as_string(actual), -- TODO Picotron has a bug that small numbers are not properly serialized
+			delta = as_string(delta), -- TODO Picotron has a bug that small numbers are not properly serialized
 			msg = serialize_message(msg),
 			file = get_caller(),
 		}
@@ -211,9 +219,9 @@ function assert_not_close(not_expected, actual, delta, msg)
 	if invalid_args or abs(not_expected - actual) <= delta then
 		local err = {
 			assert = "not_close",
-			not_expected = tostring(not_expected), -- TODO Picotron has a bug that small numbers are not properly serialized
-			actual = tostring(actual),       -- TODO Picotron has a bug that small numbers are not properly serialized
-			delta = tostring(delta),         -- TODO Picotron has a bug that small numbers are not properly serialized
+			not_expected = as_string(not_expected), -- TODO Picotron has a bug that small numbers are not properly serialized
+			actual = as_string(actual),       -- TODO Picotron has a bug that small numbers are not properly serialized
+			delta = as_string(delta),         -- TODO Picotron has a bug that small numbers are not properly serialized
 			msg = serialize_message(msg),
 			file = get_caller(),
 		}
@@ -240,7 +248,7 @@ function assert_nil(actual, msg)
 	if actual != nil then
 		local err = {
 			assert = "nil",
-			actual = tostring(actual),
+			actual = as_string(actual),
 			msg = serialize_message(msg),
 			file = get_caller(),
 		}

--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -337,7 +337,8 @@ function _draw()
 		cls()
 		gui:draw_all()
 		-- debug fps and memory usage:
-		-- print(stat(7), 250, 0, 1)
-		-- print(stat(0), 220, 10, 1)
+		-- local debug_msg = string.format("%.2f", stat(1)) ..
+		-- 	 " - " .. stat(7) .. "FPS, " .. ceil(stat(0) / 1024 / 1024) .. "MB"
+		-- print(debug_msg, 150, 5, 1)
 	end
 end


### PR DESCRIPTION
Show the original value to the user.


Partially fixes #21 