### PR TITLE
Remove assert_same and assert_not_same

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,6 @@ Test API
 * [assert_not_close](#assert_not_close)
 * [assert_nil](#assert_nil)
 * [assert_not_nil](#assert_not_nil)
-* [assert_same](#assert_same)
-* [assert_not_same](#assert_not_same)
 
 Introduction 
 ------------
@@ -91,7 +89,8 @@ Asserts that `expected` and `actual` are equal. Values must have the same type.
 For strings, numbers and booleans `==` operator is used.
 
 For tables, all keys and values are compared deeply. 
-If you want to compare if two tables points to the same address in memory please use [assert_same](#assert_same) instead. 
+If you want to check if two variables reference to the same table in memory
+please use `assert(a==b)` instead.
 Tables could have cycles.
 
 For userdata, all data is compared and userdata must be of the same type, width and height.
@@ -140,29 +139,6 @@ assert_not_nil
 **syntax:** *assert_not_nil(actual, message?)*
 
 Asserts that `actual` is not `nil`.
-
-[Back to TOC](#test-api)
-
-assert_same
------------
-
-**syntax:** *assert_same(expected, actual, message?)*
-
-Asserts that `expected` and `actual` are the same. Same as `==` operator.
-
-For tables, `expected` must be a pointer to the same address as `actual`.
-
-For strings, booleans and numbers the function behaves similar to [assert_eq](#assert_eq).  
-
-
-[Back to TOC](#test-api)
-
-assert_not_same
----------------
-
-**syntax:** *assert_same(not_expected, actual, message?)*
-
-Assert that `not_expected` and `actual` are not the same. The function has similar behavior to [assert_same](#assert_same).
 
 [Back to TOC](#test-api)
 

--- a/api.lua
+++ b/api.lua
@@ -112,8 +112,8 @@ end
 ---For strings, numbers and booleans '==' operator is used.
 ---
 ---For tables, all keys and values are compared deeply.
----If you want to compare if two tables points to the same address in memory
----please use assert_same instead.
+---If you want to check if two variables reference to the same table in memory
+---please use assert(a==b) instead.
 ---Tables could have cycles.
 ---
 ---For userdata, all data is compared and userdata must be of the same type,
@@ -158,37 +158,6 @@ local function as_string(v)
 		s = string.format('"%s"', s)
 	end
 	return s
-end
-
----@param expected any
----@param actual any
----@param msg? any message which will be presented in the unitron ui.
-function assert_same(expected, actual, msg)
-	if expected != actual then
-		local err = {
-			assert = "same",
-			expected = as_string(expected),
-			actual = as_string(actual),
-			msg = serialize_message(msg),
-			file = get_caller(),
-		}
-		error(err)
-	end
-end
-
----@param not_expected any
----@param actual any
----@param msg? any message which will be presented in the unitron ui.
-function assert_not_same(not_expected, actual, msg)
-	if not_expected == actual then
-		local err = {
-			assert = "not_same",
-			actual = as_string(actual),
-			msg = serialize_message(msg),
-			file = get_caller(),
-		}
-		error(err)
-	end
 end
 
 ---@param expected number

--- a/examples/subject_test.lua
+++ b/examples/subject_test.lua
@@ -42,18 +42,17 @@ test("assert nil", function()
 	assert_nil(v)
 end)
 
--- sometimes you want to be sure that two tables are pointing to the same
--- address in memory
-test("compare pointers", function()
-	local t = { key = "value" }
-	local pointer_to_t = t
-	-- internally assert_same just runs expected==actual:
-	assert_same(t, pointer_to_t)
-end)
-
--- standard assert function can be used too to veryify if argument is true
+-- standard assert function can be used too to verify if argument is true
 test("standard assert aka assert true", function()
 	assert(true)
+end)
+
+-- sometimes you want to be sure that two variables are referencing to the same
+-- table in memory
+test("compare references", function()
+	local t = { key = "value" }
+	local reference_to_t = t
+	assert(t == reference_to_t)
 end)
 
 -- you can nest tests multiple times. This is useful in grouping similar tests.


### PR DESCRIPTION
These functions have little value and is confusing what they do. It is not obvious how they behave when value is not a reference to a table. Also presenting pointer address to the user is not helpful at all. Whats more assert same implementations are diferent among libraries. For example, Junit's `assertSame` and Luaunit's `assertIs` works similarly to Unitron `assert_same`, but Testify's `assert.Same` fails when trying to compare strings or numbers.