### PR TITLE
[bugfix] Picotron crashes when cyclic table is used

### DIFF
--- a/api.lua
+++ b/api.lua
@@ -75,22 +75,6 @@ local function equal(expected, actual, visited_values)
 	return expected == actual
 end
 
-local function serialize_arg(v)
-	if v == nil then
-		return nil
-	end
-	local serialized = pod(v)
-	if serialized == nil then
-		if type(v) == "table" then
-			return "[cyclic table]"
-		end
-		return "[not serializable]"
-	end
-
-	-- no need to escape ] because meta data is not serialized:
-	return serialized:gsub("\\093", "]") -- TODO unescape all special characters
-end
-
 local function msg_or(msg, default)
 	if msg == nil then
 		return default
@@ -119,8 +103,8 @@ function assert_eq(expected, actual, msg)
 	if not equal(expected, actual) then
 		test_fail {
 			msg = msg_or(msg, "args not equal"),
-			expect = serialize_arg(expected),
-			actual = serialize_arg(actual)
+			expect = expected,
+			actual = actual
 		}
 	end
 end
@@ -134,20 +118,10 @@ function assert_not_eq(not_expected, actual, msg)
 	if equal(not_expected, actual) then
 		test_fail {
 			msg = msg_or(msg, "args are equal"),
-			not_expect = serialize_arg(not_expected),
-			actual = serialize_arg(actual),
+			not_expect = not_expected,
+			actual = actual,
 		}
 	end
-end
-
--- converts v to string optionally adding quotes
-local function as_string(v)
-	local s = tostring(v)
-	if type(v) == "string" then
-		-- append quotes in order to distinguish string from number
-		s = string.format('"%s"', s)
-	end
-	return s
 end
 
 ---@param expected number
@@ -161,9 +135,9 @@ function assert_close(expected, actual, delta, msg)
 	if invalid_args or abs(expected - actual) > delta then
 		test_fail {
 			msg = msg_or(msg, "args not close"),
-			expect = as_string(expected), -- TODO Picotron has a bug that small numbers are not properly serialized
-			actual = as_string(actual), -- TODO Picotron has a bug that small numbers are not properly serialized
-			delta = as_string(delta), -- TODO Picotron has a bug that small numbers are not properly serialized
+			expect = expected,
+			actual = actual,
+			delta = delta,
 		}
 	end
 end
@@ -179,9 +153,9 @@ function assert_not_close(not_expected, actual, delta, msg)
 	if invalid_args or abs(not_expected - actual) <= delta then
 		test_fail {
 			msg = msg_or(msg, "args too close"),
-			not_expect = as_string(not_expected), -- TODO Picotron has a bug that small numbers are not properly serialized
-			actual = as_string(actual),     -- TODO Picotron has a bug that small numbers are not properly serialized
-			delta = as_string(delta),       -- TODO Picotron has a bug that small numbers are not properly serialized
+			not_expect = not_expected,
+			actual = actual,
+			delta = delta,
 		}
 	end
 end
@@ -206,7 +180,7 @@ function assert_nil(actual, msg)
 	if actual != nil then
 		test_fail {
 			msg = msg_or(msg, "arg is not nil"),
-			actual = as_string(actual)
+			actual = actual
 		}
 	end
 end

--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -187,6 +187,13 @@ on_event("test_started", function(e)
 	sfx(1)
 end)
 
+---@param v any
+local function format_value(v)
+	local s = pod(v)
+	-- no need to escape ] because meta data is not serialized:
+	return s:gsub("\\093", "]") -- TODO unescape all special characters
+end
+
 -- test_finished event is published by the runner process for each started test
 on_event("test_finished", function(e)
 	if e._from != runner_pid then
@@ -222,17 +229,17 @@ on_event("test_finished", function(e)
 
 			-- always print expected first
 			if err.expect != nil then
-				print_line(e.test, "\f5 expect=\f6" .. tostring(err.expect))
+				print_line(e.test, "\f5 expect=\f6" .. format_value(err.expect))
 			end
 			-- then actual
 			if err.actual != nil then
-				print_line(e.test, "\f5 actual=\f6" .. tostring(err.actual))
+				print_line(e.test, "\f5 actual=\f6" .. format_value(err.actual))
 			end
 
 			-- TODO sort alphabetically?
 			for k, v in pairs(err) do
 				if k != "msg" and k != "expect" and k != "actual" and k != "__traceback" then
-					print_line(e.test, "\f5 " .. k .. "=\f6" .. tostring(v))
+					print_line(e.test, "\f5 " .. k .. "=\f6" .. format_value(v))
 				end
 			end
 		end

--- a/runner.lua
+++ b/runner.lua
@@ -82,6 +82,33 @@ function test(name, test)
 			}
 		end
 
+		local function prepare_to_send(value)
+			if value == nil then
+				return nil
+			end
+
+			if type(value) == "number" then
+				-- picotron is not able to send small numbers, like 0.000001
+				return tostring(value)
+			end
+
+			if pod(value) == nil then
+				if type(value) == "table" then
+					-- picotron crashes on cyclic tables
+					return "[not serializable - cyclic table]"
+				end
+				return "[not serializable]"
+			end
+
+			-- send the original value, Picotron will handle the serialization:
+			return value
+		end
+
+		-- Ensure all values can be sent to different process:
+		for key, value in pairs(err) do
+			err[key] = prepare_to_send(value)
+		end
+
 		set_error_on_parents(parent, "nested test failed")
 	end
 


### PR DESCRIPTION
When cyclic table is used in message passed to test_fail(), the
Picotron crashes. Picotron has a few bugs related to marshaling messages
sent between processes. One bug is that it crashes when message contains
cyclic table. Another bug is that Picotron is not able to pass very
small numbers (like 0.000001).