### PR TITLE
[bugfix] Unitron crashes when user selects 2nd test

### DIFF
--- a/gui/text_output.lua
+++ b/gui/text_output.lua
@@ -73,6 +73,9 @@ function attach_text_output(parent, el)
 		if -text_output.y + el.height > text_output.height then
 			text_output.y = -text_output.height + el.height
 		end
+		if text_output.y > 0 then
+			text_output.y = 0
+		end
 	end
 
 	function el:draw()


### PR DESCRIPTION
When user selects 2nd test from "lights" component, the Unitron crashes.