### PR TITLE
[bugfix] Sometimes links dont work in test output

### DIFF
--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -108,11 +108,11 @@ local function start_test(item)
 		if test_id != nil then
 			text_output:scroll_to_line(1)
 
-			test_summary.visible = false
-			lights.visible = false
+			test_summary:set_visible(false)
+			lights:set_visible(false)
 		else
-			test_summary.visible = true
-			lights.visible = true
+			test_summary:set_visible(true)
+			lights:set_visible(true)
 		end
 	end
 

--- a/gui/lights.lua
+++ b/gui/lights.lua
@@ -11,12 +11,21 @@ function attach_lights(parent, el)
 	local margin <const> = 1
 
 	el = parent:attach(el)
-	el.visible = true -- Picotron's hidden field is broken
+	el.height_before_hide = el.height
 
 	---@param no integer Starting from 1
 	function el:set_light(no, color)
 		lights[no] = color
 		lights_max = max(lights_max, no)
+	end
+
+	-- Picotron's hidden field is broken
+	function el:set_visible(v)
+		if not v then
+			el.height = 0
+		else
+			el.height = el.height_before_hide
+		end
 	end
 
 	local function light_at_cursor_pointer(msg)
@@ -35,10 +44,6 @@ function attach_lights(parent, el)
 	end
 
 	function el:update(msg)
-		if not el.visible then
-			return
-		end
-
 		if light_at_cursor_pointer(msg) != nil then
 			el.cursor = "pointer"
 		else
@@ -47,10 +52,6 @@ function attach_lights(parent, el)
 	end
 
 	function el:click(msg)
-		if not el.visible then
-			return
-		end
-
 		local light = light_at_cursor_pointer(msg)
 		if light != nil then
 			el.select(light)
@@ -58,10 +59,6 @@ function attach_lights(parent, el)
 	end
 
 	function el:draw()
-		if not el.visible then
-			return
-		end
-
 		rectfill(0, 0, el.width, el.height, 0)
 		local x, y = 0, 0
 

--- a/gui/test_summary.lua
+++ b/gui/test_summary.lua
@@ -6,14 +6,20 @@ function attach_test_summary(parent, el)
 	local succeeded, failed = 0, 0
 
 	el = parent:attach(el)
-	el.visible = true -- Picotron's hidden field is broken
+	el.height_before_hide = el.height
+
+	-- Picotron's hidden field is broken
+	function el:set_visible(v)
+		if not v then
+			el.height = 0
+		else
+			el.height = el.height_before_hide
+		end
+	end
 
 	function el:draw()
-		if not el.visible then
-			return
-		end
-
 		rectfill(0, 0, el.width, el.height, 0)
+
 		color(26)
 		print("Succeeded: " .. succeeded .. " \f8 Failed: " .. failed)
 	end


### PR DESCRIPTION
Because there are overlapping (yet hidden) components - test summary and "lights".