### PR TITLE
Show examples folder when unitron is run from ram

### DIFF
--- a/gui/gui.lua
+++ b/gui/gui.lua
@@ -326,10 +326,16 @@ function _init()
 			y = 105
 		}
 		function examples_btn:click()
+			local dir = env().corun_program or env().prog_name
+			if dir == "/ram/cart/main.lua" then
+				dir = "/ram/cart"
+			end
+			dir = dir .. "/examples"
+
 			create_process(
 				"/system/apps/filenav.p64",
 				{
-					argv = { env().prog_name .. "/examples/" },
+					argv = { dir },
 				}
 			)
 		end


### PR DESCRIPTION
When unitron is run directly from /ram/cart, the examples folder is not properly shown after user clicks "open examples" button.